### PR TITLE
change in /etc/profile and have made 3.16.0 builds possible

### DIFF
--- a/Files/profile
+++ b/Files/profile
@@ -12,6 +12,12 @@ if [ "$OS" = '3.14.0' ] && [ "$ID" -ne 0 ]; then
     cat /etc/motd
 fi
 
+# Wait until initial setup is completed
+while [ -f /etc/FIRSTBOOT ]; do
+   echo "Initial setup still in progress..."
+   sleep 1
+done
+
 # Let's set the path here since that covers both zsh and bash
 export PATH=/usr/local/bin:/bin:/usr/bin:/usr/sbin:/sbin:/usr/local/games
 
@@ -22,12 +28,6 @@ VERBOSE=0
 if [ "$CHECK" -eq 0 ] || [ "$ID" -ne 0 ]; then
    VERBOSE=1
 fi
-
-# Wait until initial setup is completed
-while [ -f /etc/FIRSTBOOT ]; do
-   echo "Initial setup still in progress..."
-   sleep 1
-done
 
 # echo $CHECK $ID $VERBOSE
 

--- a/build_image
+++ b/build_image
@@ -7,6 +7,14 @@
 . AOK_VARS
 
 
+ALPINE_RELEASE="$1"
+
+if [ -z "$ALPINE_RELEASE" ]; then
+	echo "ERROR: ALPINE_RELEASE param not supplied"
+	exit 1
+fi
+
+
 # First update apk DB
 
 echo
@@ -159,8 +167,14 @@ chmod 776 /dev/null
 #cp Files/login/login_* Files
 #popd
 
+
 mv /bin/login /bin/login.alpine
-cp Files/login.loop /bin/login
+
+if [ "$ALPINE_RELEASE" = "3.16" ]; then
+	ln -sf /bin/busybox /bin/login
+else
+	cp Files/login.loop /bin/login
+fi
 
 cp Files/login.loop /bin
 cp Files/login.once /bin

--- a/chroot_build_image
+++ b/chroot_build_image
@@ -66,7 +66,7 @@ rm "$MINIROOT_FS"
 cp /etc/resolv.conf $BUILD_D/etc
 
 # And now for the main bit
-if ! chroot $BUILD_D ./build_image ; then
+if ! chroot $BUILD_D ./build_image "$ALPINE_RELEASE"; then
   echo "ERROR in chroot"
   exit 1
 fi


### PR DESCRIPTION
/etc/profile
moved "Wait until initial setup is completed" to before the first reference to /dev/null
This change should be merged to main regardless of if you pick up the other changes since this can give errors on the first boot if /dev/null didn't get properly created during the build

Added ALPINE_RELEASE for build_image

This way alpine version specific checks can be done in build_image

In this case, preventing the in-house login binaries from initially being used for 3.16.0
I compiled them in that environment, but this did not help, so somebody with C skills needs to take a look.

This 3.16.0 check can be kept even if building for older releases since it will only do its thing if it is 3.16.0
It will be good to have the release info in build_image anyway, this way other checks can be done when needed

So not only meaningful for 3.16 builds