### PR TITLE
Added param to select where to chroot into, and corrected hardcoded dirs

### DIFF
--- a/tools/do_chroot.sh
+++ b/tools/do_chroot.sh
@@ -3,9 +3,16 @@
 #  Copyright (c) 2022: Jacob.Lundqvist@gmail.com
 #  License: MIT
 #
-#  Version: 1.1.0 2022-06-17
+#  Version: 1.2.0 2022-06-19
 #
-#  if $1 param is supplied run that in the chroot, otherwise default to bash -l
+#  if $1 is -p $2 is assumed to be the path to chroot in-to, it defaults to
+#  BUILD_ROOT_D if not given. After -p and the dir is processed those two
+#  parameters are shifted, so the potential command to be run should be given
+#  after this.
+#
+#  If (what is now) $1 param is supplied, run that command in the chroot,
+#  otherwise default to bash -l, if more than one word, the command and its
+#  parameters needs to be quoted: '/bin/sh -l'
 #
 
 #  shellcheck disable=SC1007
@@ -21,10 +28,27 @@ cd "$FS_BUILD_D" || exit 1
 # shellcheck disable=SC1091
 . ./BUILD_ENV
 
+
 if [ "$(whoami)" != "root" ]; then
     echo "ERROR: This must be run as root or using sudo!"
     echo
     exit 1
+fi
+
+CHROOT_TO="$BUILD_ROOT_D"
+if [ "$1" = "-p" ]; then
+    if [ -n "$2" ]; then
+        CHROOT_TO="$2"
+        if [ ! -d "$CHROOT_TO" ]; then
+            echo "ERROR: [$CHROOT_TO] is not a directory!"
+            exit 1
+        fi
+        shift # get rid of the param
+        shift # get rid of the dir
+    else
+        echo "ERROR: -p assumes a param pointing to where to chroot!"
+        exit 1
+    fi
 fi
 
 echo "=====  Preparing the environment for chroot  ====="
@@ -32,23 +56,23 @@ echo "=====  Preparing the environment for chroot  ====="
 
 echo "---  Mounting system resources  ---"
 
-mount -t proc proc "$BUILD_ROOT_D"/proc
+mount -t proc proc "$CHROOT_TO"/proc
 
 if [ -d "/proc/ish" ]; then
     echo "---  Setting up needed /dev items  ---"
 
-    mknod "$BUILD_ROOT_D"/dev/null c 1 3
-    chmod 666 "$BUILD_ROOT_D"/dev/null
+    mknod "$CHROOT_TO"/dev/null c 1 3
+    chmod 666 "$CHROOT_TO"/dev/null
 
-    mknod "$BUILD_ROOT_D"/dev/urandom c 1 9
-    chmod 666 "$BUILD_ROOT_D"/dev/urandom
+    mknod "$CHROOT_TO"/dev/urandom c 1 9
+    chmod 666 "$CHROOT_TO"/dev/urandom
 
-    mknod "$BUILD_ROOT_D"/dev/zero c 1 5
-    chmod 666 "$BUILD_ROOT_D"/dev/zero
+    mknod "$CHROOT_TO"/dev/zero c 1 5
+    chmod 666 "$CHROOT_TO"/dev/zero
 else
-    # mount -o bind /tmp /tmp/AOK/iSH-AOK-FS/tmp
-    mount -t sysfs sys /tmp/AOK/iSH-AOK-FS/sys
-    mount -o bind /dev /tmp/AOK/iSH-AOK-FS/dev
+    # mount -o bind /tmp "$CHROOT_TO"/tmp
+    mount -t sysfs sys "$CHROOT_TO"/sys
+    mount -o bind /dev "$CHROOT_TO"/dev
 fi
 
 
@@ -59,12 +83,12 @@ else
 fi
 
 
-echo "=====  Do the chroot ($cmd)  ====="
+echo "=====  chrooting to: $CHROOT_TO ($cmd)  ====="
 
 
 # In this case we want the variable to expand into its components
 # shellcheck disable=SC2086
-chroot "$BUILD_ROOT_D" $cmd
+chroot "$CHROOT_TO" $cmd
 exit_code="$?"
 
 
@@ -74,15 +98,15 @@ echo "=====  Doing some post chroot cleanup  ====="
 
 echo "---  Un-mounting system resources  ---"
 
-umount /tmp/AOK/iSH-AOK-FS/proc
+umount "$CHROOT_TO"/proc
 
 if [ -d "/proc/ish" ]; then
     echo "---  Removing the temp /dev entries"
-    rm -f "$BUILD_ROOT_D"/dev/*
+    rm -f "$CHROOT_TO"/dev/*
 else
-    # umount /tmp/AOK/iSH-AOK-FS/tmp
-    umount /tmp/AOK/iSH-AOK-FS/sys
-    umount /tmp/AOK/iSH-AOK-FS/dev
+    # umount "$CHROOT_TO"/tmp
+    umount "$CHROOT_TO"/sys
+    umount "$CHROOT_TO"/dev
 fi
 
 


### PR DESCRIPTION
Fixed hard-coded paths to use BUILD_ROOT_D as default

if -p  and an (existing) dir is given, this will override the default
the optional command to run inside the chroot should be given after -p <dir>

This made it convenient to chroot into that ubuntu FS that was posted :)