### PR TITLE
Fixes aborted chroot

### DIFF
--- a/build_fs
+++ b/build_fs
@@ -63,10 +63,12 @@ if [ "$(whoami)" != "root" ]; then
     exit 1
 fi
 
-if [ "$(find "$BUILD_ROOT_D"/dev | wc -l)" -gt 1 ]; then
+
+if      mount | grep -q "$BUILD_ROOT_D" || \
+        [ "$(find "$BUILD_ROOT_D"/dev | wc -l)" -gt 1 ]; then
     echo "ERROR: Active chroot session detected!"
     echo "       If this is due to a crash, you can clear it by running:"
-    echo "         sudo rm $BUILD_ROOT_D/dev/*"
+    echo "         sudo ./tools/do_chroot.sh -c"
     echo
     exit 1
 fi

--- a/tools/do_chroot.sh
+++ b/tools/do_chroot.sh
@@ -3,16 +3,8 @@
 #  Copyright (c) 2022: Jacob.Lundqvist@gmail.com
 #  License: MIT
 #
-#  Version: 1.2.0 2022-06-19
+#  Version: 1.3.0 2022-06-27
 #
-#  if $1 is -p $2 is assumed to be the path to chroot in-to, it defaults to
-#  BUILD_ROOT_D if not given. After -p and the dir is processed those two
-#  parameters are shifted, so the potential command to be run should be given
-#  after this.
-#
-#  If (what is now) $1 param is supplied, run that command in the chroot,
-#  otherwise default to bash -l, if more than one word, the command and its
-#  parameters needs to be quoted: '/bin/sh -l'
 #
 
 #  shellcheck disable=SC1007
@@ -21,12 +13,16 @@ FS_BUILD_D="$(dirname "$CURRENT_D")"
 
 #
 #  Ensure this is run in the intended location in case this was launched from
-#  somewhere else.
+#  somewhere else, this to ensure BUILD_ENV can be found
 #
 cd "$FS_BUILD_D" || exit 1
 
 # shellcheck disable=SC1091
 . ./BUILD_ENV
+
+
+prog_name=$(basename "$0")
+CHROOT_TO="$BUILD_ROOT_D"
 
 
 if [ "$(whoami)" != "root" ]; then
@@ -35,45 +31,111 @@ if [ "$(whoami)" != "root" ]; then
     exit 1
 fi
 
-CHROOT_TO="$BUILD_ROOT_D"
-if [ "$1" = "-p" ]; then
-    if [ -n "$2" ]; then
-        CHROOT_TO="$2"
-        if [ ! -d "$CHROOT_TO" ]; then
-            echo "ERROR: [$CHROOT_TO] is not a directory!"
+
+
+env_prepare() {
+    echo "=====  Preparing the environment for chroot  ====="
+
+
+    echo "---  Mounting system resources  ---"
+
+    mount -t proc proc "$CHROOT_TO"/proc
+
+    if [ -d "/proc/ish" ]; then
+        echo "---  Setting up needed /dev items  ---"
+
+        mknod "$CHROOT_TO"/dev/null c 1 3
+        chmod 666 "$CHROOT_TO"/dev/null
+
+        mknod "$CHROOT_TO"/dev/urandom c 1 9
+        chmod 666 "$CHROOT_TO"/dev/urandom
+
+        mknod "$CHROOT_TO"/dev/zero c 1 5
+        chmod 666 "$CHROOT_TO"/dev/zero
+    else
+        # mount -o bind /tmp "$CHROOT_TO"/tmp
+        mount -t sysfs sys "$CHROOT_TO"/sys
+        mount -o bind /dev "$CHROOT_TO"/dev
+    fi
+}
+
+env_cleanup() {
+    echo
+    echo "=====  Doing some post chroot cleanup  ====="
+
+
+    echo "---  Un-mounting system resources  ---"
+
+    umount "$CHROOT_TO"/proc
+
+    if [ -d "/proc/ish" ]; then
+        echo "---  Removing the temp /dev entries"
+        rm -f "$CHROOT_TO"/dev/*
+    else
+        # umount "$CHROOT_TO"/tmp
+        umount "$CHROOT_TO"/sys
+        umount "$CHROOT_TO"/dev
+    fi
+}
+
+show_help() {
+    cat <<EOF
+Usage: $prog_name [-h] | [-u] | [-p dir] command
+
+chroot with env setup so this works on both Linux & iSH
+
+Available options:
+
+-h, --help     Print this help and exit
+-c  --cleanup  Cleanup env
+-p, --path     What dir to chroot into, defaults to: $BUILD_ROOT_D
+command        What to run, defaults to "bash -l", command params must be quoted!
+EOF
+
+}
+
+
+
+case "$1" in
+
+    "-h" | "--help" )
+        show_help
+        exit 0
+        ;;
+
+    "-p" | "--path" )
+        if [ -n "$2" ]; then
+            CHROOT_TO="$2"
+            if [ ! -d "$CHROOT_TO" ]; then
+                echo "ERROR: [$CHROOT_TO] is not a directory!"
+                exit 1
+            fi
+            shift  # get rid of the option
+            shift  # get rid of the dir
+        else
+            echo "ERROR: -p assumes a param pointing to where to chroot!"
             exit 1
         fi
-        shift # get rid of the param
-        shift # get rid of the dir
-    else
-        echo "ERROR: -p assumes a param pointing to where to chroot!"
-        exit 1
-    fi
-fi
+        ;;
 
-echo "=====  Preparing the environment for chroot  ====="
+    "-c" | "--cleanup" )
+        env_cleanup
+        exit 0
+        ;;
+
+    *)
+        firstchar="$(echo "$1" | cut -c1-1)"
+        if [ "$firstchar" = "-" ]; then
+            echo "ERROR: invalid option! Try using: -h"
+            exit 1
+        fi
+        ;;
+
+esac
 
 
-echo "---  Mounting system resources  ---"
 
-mount -t proc proc "$CHROOT_TO"/proc
-
-if [ -d "/proc/ish" ]; then
-    echo "---  Setting up needed /dev items  ---"
-
-    mknod "$CHROOT_TO"/dev/null c 1 3
-    chmod 666 "$CHROOT_TO"/dev/null
-
-    mknod "$CHROOT_TO"/dev/urandom c 1 9
-    chmod 666 "$CHROOT_TO"/dev/urandom
-
-    mknod "$CHROOT_TO"/dev/zero c 1 5
-    chmod 666 "$CHROOT_TO"/dev/zero
-else
-    # mount -o bind /tmp "$CHROOT_TO"/tmp
-    mount -t sysfs sys "$CHROOT_TO"/sys
-    mount -o bind /dev "$CHROOT_TO"/dev
-fi
+env_prepare
 
 
 if [ "$1" = "" ]; then
@@ -82,33 +144,15 @@ else
     cmd="$1"
 fi
 
-
 echo "=====  chrooting to: $CHROOT_TO ($cmd)  ====="
 
-
-# In this case we want the variable to expand into its components
+# In this case we want the $cmd variable to expand into its components
 # shellcheck disable=SC2086
 chroot "$CHROOT_TO" $cmd
 exit_code="$?"
 
 
-echo
-echo "=====  Doing some post chroot cleanup  ====="
-
-
-echo "---  Un-mounting system resources  ---"
-
-umount "$CHROOT_TO"/proc
-
-if [ -d "/proc/ish" ]; then
-    echo "---  Removing the temp /dev entries"
-    rm -f "$CHROOT_TO"/dev/*
-else
-    # umount "$CHROOT_TO"/tmp
-    umount "$CHROOT_TO"/sys
-    umount "$CHROOT_TO"/dev
-fi
-
+env_cleanup
 
 # If there was an error in the chroot process, propagate it
 exit "$exit_code"


### PR DESCRIPTION
I noticed a fairly important issue. If the chroot was aborted in a way that prevents it from doing cleanup, there was no easy way to fix it without unmounting stuff manually.

I added help and more options to tools/do_chroot.sh. And now build_fs suggests running 
./do_chroot.sh -c if it detects that a previous run did not clean up itself.

Next to fix is to make sure do_chroot doesn't skip cleanup if Ctrl-C is hit during the chrooted part of build_fs
Handling Ctrl-C isn't complicated, but it's a bit late so will do that next time around.

But since this both fixes this issue and will be useful if there are other unintended exits of do_chroot, it makes sense to get it in asap.

Test procedure:
- run  ./build_fs
- Ctrl-C Whilst in the chroot, like during installation of the "---  Add initial packages  ---"
- run ./build_fs again, observe the error message and follow the suggested fix
- run build_fs - now it should run normally