### PR TITLE
separated AOK version & Alpine release

### DIFF
--- a/AOK_VARS
+++ b/AOK_VARS
@@ -6,7 +6,7 @@
 # A list of variables used during build and for /usr/local/bin stuff
 #
 
-AOK_VERSION="ALPHA-98_3.14"
+AOK_VERSION="Alpha-98"
 
 #
 #  ALPINE_VERSION defines what alpine-minirootfs will be used as a baseline

--- a/BUILD_ENV
+++ b/BUILD_ENV
@@ -19,14 +19,15 @@ BUILD_ROOT_D="$BUILD_BASE_D/iSH-AOK-FS"
 # If this is run on an iSH node, the image is copied to this location
 ICLOUD_ARCHIVE_D="/iCloud/AOK_Archive"
 
-# extract the release/branch/major version
+# extract the release/branch/major version, gives something like 3.14
 ALPINE_RELEASE="$(echo "$ALPINE_VERSION" | cut -d"." -f 1,2)"
+
 
 # mini-root fs to be downloaded and used
 MINIROOT_FS="alpine-minirootfs-${ALPINE_VERSION}-x86.tar.gz"
 
 # the deploy-able iSH filesystem image name.
-AOK_FS="ALPINE_${ALPINE_VERSION}-iSH-AOK_${AOK_VERSION}.tgz"
+AOK_FS="ALPINE_${ALPINE_VERSION}-iSH-AOK_${AOK_VERSION}_${ALPINE_RELEASE}.tgz"
 
 #
 # Hint to iSH this is the first time booting. Checked for by

--- a/Files/issue
+++ b/Files/issue
@@ -1,4 +1,4 @@
 
-Welcome to the A-OK iSH Filesystem 
-       Version: Alpha .98
+Welcome to the A-OK iSH Filesystem
+       Version: AOK_VERSION
 

--- a/Files/motd
+++ b/Files/motd
@@ -1,6 +1,6 @@
-[35m   Welcome to the A-OK iSH 
+[35m   Welcome to the A-OK iSH
   Alpine Linux Shell iMage.
-    Version: Alpha .98[0m
+    Version: AOK_VERSION[0m
 [34m
             █▌
             ▀▘

--- a/setup_image_chrooted
+++ b/setup_image_chrooted
@@ -105,10 +105,9 @@ cp /AOK/Files/init.d/* /root/init.d
 cp /AOK/Files/inittab /etc
 
 # Custom MOTD/issue
-rm /etc/motd
-cp /AOK/Files/motd /etc
-rm /etc/issue
-cp /AOK/Files/issue /etc
+sed "s/AOK_VERSION/$AOK_VERSION/" /AOK/Files/motd > /etc/motd
+sed "s/AOK_VERSION/$AOK_VERSION/" /AOK/Files/issue > /etc/issue
+
 
 # Sudoers stuff, group wheel can do sudo without password
 echo "activating group wheel for passwordless sudo"
@@ -201,7 +200,7 @@ sed -i 's/\/bin\/ash$/\/bin\/bash/' /etc/passwd
 # Make a directory to later mount the iCloud drive on
 mkdir /iCloud
 
-echo "$AOK_VERSION" > /etc/aok_release
+echo "${AOK_VERSION}_${ALPINE_RELEASE}" > /etc/aok_release
 
 
 echo "---  Initial login method  ---"


### PR DESCRIPTION
As per request, AOK_VERSION is separated from the Alpine release :)

Instead of copying motd & issue to their locations I have set up a template version and use sed to copy the files with current AOK_VERSION to their destination

The only change is that right now you can not use space in AOK_VERSION since it is used to create a filename for the image.
If you really want to be able to use space when displaying AOK_VERSION, let me know, its fairly easy to add that additional replacement as the version is sed processed