### PR TITLE
/etc/aok_release -> /etc/aok-release

### DIFF
--- a/setup_image_chrooted
+++ b/setup_image_chrooted
@@ -201,7 +201,7 @@ sed -i 's/\/bin\/ash$/\/bin\/bash/' /etc/passwd
 # Make a directory to later mount the iCloud drive on
 mkdir /iCloud
 
-echo "$AOK_VERSION" > /etc/aok_release
+echo "$AOK_VERSION" > /etc/aok-release
 
 
 echo "---  Initial login method  ---"


### PR DESCRIPTION
Alpine uses the name /etc/alpine-release, so it makes more sense to use dash over underscore in order to be consistent