### PR TITLE
Jaclu remove bad man dir

### DIFF
--- a/Files/sbin/post_boot.sh
+++ b/Files/sbin/post_boot.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-#  Version: 1.3.1  2022-06-15
+#  Version: 1.3.2  2022-07-26
 #
 #  Intended usage is for small systems where a cron might not be running and or
 #  needing to do some sanity checks after booting.
@@ -98,6 +98,19 @@ if [ -e /etc/FIRSTBOOT ]; then
     echo "FIRSTBOOT tasks done"
     rm /etc/FIRSTBOOT # Only do this stuff once, so remove the file now
 fi
+
+
+#
+#  Sometimes this supposedly man dir ends up being a text file for no obvious
+#  reason. This prevents man-db from being properly installed.
+#  This snippet removes it if it is a regular file and not a dir
+#
+fname_man1="/usr/share/man/man1"
+if [ -f "$fname_man1" ] && [ ! -d "$fname_man1" ]; then
+    echo "Removing text-file that should not exist: $fname_man1"
+    rm "$fname_man1"
+fi
+unset fname_man1
 
 
 # /etc/init.d/networking keeps getting an extra } written at the end

--- a/README.md
+++ b/README.md
@@ -10,3 +10,16 @@ Further instructions will be displayed when this is run
 
 Tweak build settings in `./AOK_VARS`
 
+## Tool Versions
+
+Check with -h or -v
+
+If you don't have the latest version of the script you intend to use,
+update your repository!
+
+Vers | script
+-|-
+1.3.2 | build_fs
+1.3.0 | aok_setup_fs
+1.3.3 | compress_image
+1.3.0 | tools/do_chroot.sh

--- a/compress_image
+++ b/compress_image
@@ -7,7 +7,7 @@
 #
 #  Compresses a FS into a tar file that can be mounted by iSH
 #
-version="1.3.2"
+version="1.3.3"
 
 #  shellcheck disable=SC1007
 fs_build_d=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
@@ -141,12 +141,12 @@ tar "$opts" - . | gzip -9 > "../$tgz_file"
 if [ "$build_env" -eq 1 ]; then
     echo "---  Copying image into $ICLOUD_ARCHIVE_D  ---"
     mkdir -p "$ICLOUD_ARCHIVE_D"
-    cp "$BUILD_BASE_D/$AOK_FS" "$ICLOUD_ARCHIVE_D"
+    cp "$BUILD_BASE_D/$tgz_file" "$ICLOUD_ARCHIVE_D"
 fi
 echo
 
 
-echo "=====  Image is ready: $BUILD_BASE_D/$AOK_FS  ====="
+echo "=====  Image is ready: $BUILD_BASE_D/$tgz_file  ====="
 echo
 
 


### PR DESCRIPTION
I have noticed that from time to time, what is meant to be one of the man dirs, /usr/share/man/man1 becomes occupied by a text file. This prevents man-db from properly installing, causing man pages to fail.
As of yet I have no clue what creates this file, but by adding a snippet in /usr/local/sbin/post_boot.sh that removes this item if it is a file and not a directory fixes the issue.

Once I figure out why this seemingly random file sometimes gets created, a solution to the cause hopefully can be found, but since this has no downsides,  it makes sense to add this additional post_boot.sh task