### PR TITLE
removed no longer needed man-page check

### DIFF
--- a/Files/sbin/post_boot.sh
+++ b/Files/sbin/post_boot.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-#  Version: 1.3.2  2022-07-26
+#  Version: 1.3.3  2022-07-27
 #
 #  Intended usage is for small systems where a cron might not be running and or
 #  needing to do some sanity checks after booting.
@@ -14,7 +14,7 @@
 #    * services sometimes fail to start by init, restarting them here
 #      tends to help
 
-post_boot_log=/tmp/post_boot.log
+post_boot_log=/var/log/post_boot.log
 
 respawn_it() {
     tmp_log_file="/tmp/post_boot-$$"
@@ -98,19 +98,6 @@ if [ -e /etc/FIRSTBOOT ]; then
     echo "FIRSTBOOT tasks done"
     rm /etc/FIRSTBOOT # Only do this stuff once, so remove the file now
 fi
-
-
-#
-#  Sometimes this supposedly man dir ends up being a text file for no obvious
-#  reason. This prevents man-db from being properly installed.
-#  This snippet removes it if it is a regular file and not a dir
-#
-fname_man1="/usr/share/man/man1"
-if [ -f "$fname_man1" ] && [ ! -d "$fname_man1" ]; then
-    echo "Removing text-file that should not exist: $fname_man1"
-    rm "$fname_man1"
-fi
-unset fname_man1
 
 
 # /etc/init.d/networking keeps getting an extra } written at the end


### PR DESCRIPTION
Resolved bad man page occupying /usr/share/man/man1

Turned out it was my spd deploy, I manually copied some man pages to /usr/share/man/man1
Up to recently prior to that point man-db had been installed, so the directory existed, a recent spd change
removed install of man-db during deploy, and lead to this broken man directory being created,
big oops, but resolved now.