### PR TITLE
3.16 no longer has busybox-extras

### DIFF
--- a/build_fs
+++ b/build_fs
@@ -9,7 +9,7 @@
 #  Primary purpose is to create iSH-AOK file systems, but can also be used
 #  to create bare-bones Alpine-Linux file systems.
 #
-version="1.3.2"
+version="1.3.3"
 
 
 #  shellcheck disable=SC1007
@@ -248,6 +248,13 @@ mkdir "$aok_files"
 
 mv "$BUILD_ROOT_D"/BUILD_ENV         "$aok_files"
 mv "$BUILD_ROOT_D"/AOK_VARS          "$aok_files"
+
+#  busybox-extras no longer a package starting with 3.16, so delete if present
+if [ "$ALPINE_RELEASE" \> "3.15" ]; then
+    echo "removing busybox-extras from core apks, not available past 3.15"
+    sed -i "s/busybox\-extras//" "$aok_files"/AOK_VARS
+fi
+
 mv "$BUILD_ROOT_D"/build_fs          "$aok_files"
 mv "$BUILD_ROOT_D"/aok_setup_fs      "$aok_files"
 mv "$BUILD_ROOT_D"/compress_image    "$aok_files"


### PR DESCRIPTION
busybox-extras is no longer a package starting with 3.16
first-boot will fail if attempting to install it as part of CORE_APKS on 3.16
In my testings so far I have just manually removed it up to now, but that is just an obvious failure point, so I included a release check and if release is > 3.15 
busybox-extras will be removed from CORE_APKS