### PR TITLE
Avoid race condition & more obvious 'not root' errors

### DIFF
--- a/AOK_VARS
+++ b/AOK_VARS
@@ -34,7 +34,7 @@ ALPINE_VERSION=3.14.8   # End of Alpine support 2023-05-01
 #  If defined, this will be run at the end of first boot, at a time when
 #  it should be a full AOK FS
 #
-FIRST_BOOT_ADDITIONAL_TASKS="" #"date ; echo 'one more date'; date"
+FIRST_BOOT_ADDITIONAL_TASKS="" #"/iCloud/spd/bin/deploy-ish"
 
 #
 #  The system will be initially set to this timezone

--- a/Files/sbin/post_boot.sh
+++ b/Files/sbin/post_boot.sh
@@ -127,12 +127,19 @@ if [ -e /etc/FIRSTBOOT ]; then
     rc-update add dcron
     rc-service dcron restart
 
+    #
+    #  Do this before run_additional_tasks_if_found to avoid getting stuck
+    #  if the FIRST_BOOT_ADDITIONAL_TASKS does a sudo or something else
+    #  processing /etc/profile. In such a case that process would otherwise
+    #  get stuck forever, waiting for this file to be removed.
+    #
+    rm /etc/FIRSTBOOT # Only do this stuff once, so remove the file now
+
     run_additional_tasks_if_found
 
     echo
     echo "FIRSTBOOT tasks done"
 
-    rm /etc/FIRSTBOOT # Only do this stuff once, so remove the file now
 fi
 
 

--- a/build_fs
+++ b/build_fs
@@ -9,7 +9,7 @@
 #  Primary purpose is to create iSH-AOK file systems, but can also be used
 #  to create bare-bones Alpine-Linux file systems.
 #
-version="1.3.4"
+version="1.3.5"
 
 
 #  shellcheck disable=SC1007
@@ -39,7 +39,7 @@ show_help() {
     cat <<EOF
 $prog_name, version $version
 
-Usage: $prog_name [-h] [-v] [-c] [-m] [-M]
+Usage: $prog_name [-h] [-v] [-p] [-c] [-z] [-u]
 
 This builds the iSH-AOK filesystem.
 
@@ -132,9 +132,9 @@ display_build_env() {
 
     if [ "$(whoami)" != "root" ]; then
         # Must come after help display, to avoid infinite loop
-        echo "ERROR: This must be run as root or using sudo!"
+        "$0" -h
         echo
-        "$fs_build_d/$prog_name" -h
+        echo "ERROR: This must be run as root or using sudo!"
         exit 1
     fi
 

--- a/compress_image
+++ b/compress_image
@@ -7,7 +7,7 @@
 #
 #  Compresses a FS into a tar file that can be mounted by iSH
 #
-version="1.3.3"
+version="1.3.4"
 
 #  shellcheck disable=SC1007
 fs_build_d=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
@@ -31,7 +31,7 @@ show_help() {
     cat <<EOF
 $prog_name, version $version
 
-Usage: $prog_name [-h] [-v] [-c] [-m] [-M]
+Usage: $prog_name [-h] [-v] [-z]
 
 This creates a compressed tar file. that iSH can mount as a file syste,
 
@@ -73,8 +73,10 @@ done
 
 
 if [ "$(whoami)" != "root" ]; then
-    echo "ERROR: This must be run as root or using sudo!"
+    # Must come after help display, to avoid infinite loop
+    "$0" -h
     echo
+    echo "ERROR: This must be run as root or using sudo!"
     exit 1
 fi
 


### PR DESCRIPTION
In the perhaps rather peculiar case that the FIRST_BOOT_ADDITIONAL_TASKS does sudo or anything else reading /etc/profile

This is probably not a crucial PR for the upcoming release, it took me two weeks before I tried an additional task that complex, but I guess you never know