### PR TITLE
Improved handling of .AOK_VARS fixed issues in aok_groups

### DIFF
--- a/AOK_VARS
+++ b/AOK_VARS
@@ -109,21 +109,3 @@ NODEJS_APKS='nodejs nodejs-dev'
 BLOAT3_APKS='emacs neofetch'
 
 DOCS_APKS='openssh-doc openrc-doc nload-doc htop-doc procps-doc tmux-doc mandoc shadow-doc mosh-doc fortune-doc tzdata-doc elinks-doc dcron-doc vim-doc ncftp-doc coreutils-doc findutils-doc tar-doc ncurses-doc less-doc sed-doc gawk-doc grep-doc util-linux-doc tzdata-doc x11vnc-doc xdpyinfo-doc i3wm-doc i3lock-doc i3status-doc strace-doc mandoc man-pages bash-doc strace-doc procps-doc rsync-doc htop-doc'
-
-# =====================================================================
-#
-#  Local overrides, ignored by git. They will be appended to AOK_VARS
-#  for the deployed image if found.
-#  This is intended for debuging and testing.
-#  This way on the deployed platform it will be easy to spot what
-#  temp/devel settings was used in the build process.
-#
-# =====================================================================
-
-###  override handling  ###
-
-local_overrides="/opt/AOK/.AOK_VARS"
-
-#  shellcheck disable=SC1090
-[ -f "$local_overrides" ] && . "$local_overrides"
-unset local_overrides

--- a/AOK_VARS
+++ b/AOK_VARS
@@ -52,6 +52,18 @@ ALPINE_VERSION=3.16.3 # End of Alpine support 2024-05-23
 # FIRST_BOOT_ADDITIONAL_TASKS="/iCloud/spd/bin/deploy-ish"
 
 #
+#  Should normally not be changed! Enabling his will create a limited env
+#  missing features and functionality!
+#
+#  Purpose is to speed up the deploy cycle when testing and improving
+#  the build processess on slow devices, by cutting down on deploy heavy
+#  usability features
+#  Enble by setting this to 1
+#  Ideal candidate to modify in .AOK_VARS
+#
+QUICK_DEPLOY=0
+
+#
 #  Always installed packages
 #
 CORE_APKS="openssh openrc zsh bash tmux git curl openssl-dev shadow sudo busybox-extras mosh fortune elinks dcron dcron-openrc vim nano ssl_client ncftp coreutils findutils tar ncurses-dev ncurses file less sed gawk grep util-linux tzdata rsync"
@@ -78,18 +90,6 @@ CORE_DEB_PKGS="tzdata psmisc file curl less zsh git tmux mosh elinks nano gawk r
 #  If defined this user will be created
 #
 USER_NAME="ish"
-
-#
-#  Should normally not be changed! Enabling his will create a limited env
-#  missing features and functionality!
-#
-#  Purpose is to speed up the deploy cycle when testing and improving
-#  the build processess on slow devices, by cutting down on deploy heavy
-#  usability features
-#  Enble by setting this to 1
-#  Ideal candidate to modify in .AOK_VARS
-#
-QUICK_DEPLOY=0
 
 #
 #  Additional APK groups managed with /usr/local/bin/aok_groups

--- a/Alpine/usr_local_bin/aok_groups
+++ b/Alpine/usr_local_bin/aok_groups
@@ -124,7 +124,7 @@ process_items() {
         name="$(echo "$section" | cut -d'|' -f 1 | awk '{$1=$1};1' | tr '[:upper:]' '[:lower:]')"
         packages="$(echo "$section" | cut -d'|' -f 2 | awk '{$1=$1};1')"
 
-        [ -z "$name" ] && continue # skip blank lines
+        [ -z "$packages" ] && continue # skip empty groups
 
         case "$task" in
 

--- a/Alpine/usr_local_bin/aok_groups
+++ b/Alpine/usr_local_bin/aok_groups
@@ -74,6 +74,7 @@ use_aok_groups() {
     #  Convert $var_file to my notation, so that it can be used without
     #  changing the rest of the code.
     #
+    # shellcheck disable=SC1090
     . "$conf_file"
     package_groups="$(
         set |

--- a/Alpine/usr_local_bin/aok_groups
+++ b/Alpine/usr_local_bin/aok_groups
@@ -5,13 +5,11 @@
 #
 #  Who said you couldn't do nested arrays in POSIX ??
 #
-version="0.6.0  2022-06-13"
-
+version="1.0.0  2023-02-06"
 
 prog_name=$(basename "$0")
 
 force_mode=0
-
 
 #
 #  By only displaying actions on other OS
@@ -23,77 +21,78 @@ else
     is_iSH=0
 fi
 
-
 check_for_option() {
     case "$1" in
 
-        "" | "-h" | "--help" )
-            echo "usage: $prog_name [-h] | [-g] | [-l] | [-f] | group1 group2 -group3 ..."
-            echo
-            echo "This is a tool to install/uninstall groups of packages"
-            echo "prefixing a group name with - means uninstall that group"
-            echo
-            echo "options:"
-            echo "  -h, --help   show this help message and exit"
-            echo "  -g           list available groups and exit"
-            echo "  -l           list groups and items and exit"
-            echo "  -f  --force  installs/deletes will be done even if not running"
-            echo "               on iSH. This is for preparing a FS when chrooted"
-            echo
-            exit 0
-            ;;
+    "" | "-h" | "--help")
+        echo "usage: $prog_name [-h] | [-g] | [-l] | [-f] | group1 group2 -group3 ..."
+        echo
+        echo "This is a tool to install/uninstall groups of packages"
+        echo "prefixing a group name with - means uninstall that group"
+        echo
+        echo "options:"
+        echo "  -h, --help   show this help message and exit"
+        echo "  -g           list available groups and exit"
+        echo "  -l           list groups and items and exit"
+        echo "  -f  --force  installs/deletes will be done even if not running"
+        echo "               on iSH. This is for preparing a FS when chrooted"
+        echo
+        exit 0
+        ;;
 
-        "-g" )
-            task="groups"
-            process_items
-            echo
-            exit 0
-            ;;
+    "-g")
+        task="groups"
+        process_items
+        echo
+        exit 0
+        ;;
 
-        "-l" )
-            task="list"
-            process_items
-            exit 0
-            ;;
+    "-l")
+        task="list"
+        process_items
+        exit 0
+        ;;
 
-        "-f" | "--force" )
-            force_mode=1
-            is_iSH=1
-            ;;
+    "-f" | "--force")
+        force_mode=1
+        is_iSH=1
+        ;;
 
-        *) ;;
+    *) ;;
 
     esac
 }
 
-
 use_aok_groups() {
-    var_file="/opt/AOK/AOK_VARS"
-    if [ ! -f "$var_file" ]; then
-        echo "ERROR: $var_file not found!"
+    conf_file="/opt/AOK/AOK_VARS"
+    if [ ! -f "$conf_file" ]; then
+        echo "ERROR: $conf_file not found!"
         exit 1
     fi
+
     #
     #  Convert $var_file to my notation, so that it can be used without
     #  changing the rest of the code.
     #
-    #package_groups="$(grep _APKS "$var_file"  | grep -v '#' | sed -e s/_APKS// -e s/BLOAT// -e s/\'//g -e s/=/\|/ | awk '{ print ":" $0 }')"
-
-    package_groups="$(grep _APKS "$var_file" | grep -v '#' |
-                      sed -e s/_APKS// -e s/BLOAT// -e "s/'//g" -e s/=/\|/ |
-                      awk '{ print ":" $0 }')"
+    . "$conf_file"
+    package_groups="$(
+        set |
+            grep _APKS |
+            sed -e s/_APKS// -e s/BLOAT// -e "s/'//g" -e s/=/\|/ |
+            awk '{ print ":" $0 }'
+    )"
 }
-
 
 pkg_handling() {
     action="$1"
     case "$action" in
 
-        "add" | "del" ) ;;
+    "add" | "del") ;;
 
-        *)
-            echo "ERROR: pkg_handling() - incorrect param: $action"
-            exit 1
+    *)
+        echo "ERROR: pkg_handling() - incorrect param: $action"
+        exit 1
+        ;;
     esac
 
     cmd="sudo apk $action $packages"
@@ -109,7 +108,6 @@ pkg_handling() {
     task_done=1
 }
 
-
 #
 #  Loops through all groups, and takes action according to $task
 #  for install / uninstall $item is assumed to be the group to be
@@ -117,75 +115,74 @@ pkg_handling() {
 #
 process_items() {
     task_done=0
-    lst=$package_groups  # since we might come back, don't change the original :)
+    lst=$package_groups # since we might come back, don't change the original :)
     while true; do
         # POSIX way to handle array types of data
-        section="${lst%%:*}"  # up to first colon excluding it
-        lst="${lst#*:}"       # after fist colon
+        section="${lst%%:*}" # up to first colon excluding it
+        lst="${lst#*:}"      # after fist colon
 
-        name="$(echo     "$section" | cut -d'|' -f 1| awk '{$1=$1};1' | tr '[:upper:]' '[:lower:]')"
-        packages="$(echo "$section" | cut -d'|' -f 2| awk '{$1=$1};1')"
+        name="$(echo "$section" | cut -d'|' -f 1 | awk '{$1=$1};1' | tr '[:upper:]' '[:lower:]')"
+        packages="$(echo "$section" | cut -d'|' -f 2 | awk '{$1=$1};1')"
 
-        [ -z "$name" ] && continue  # skip blank lines
+        [ -z "$name" ] && continue # skip blank lines
 
         case "$task" in
 
-            "groups") printf "%s" "$name " ;;
+        "groups") printf "%s" "$name " ;;
 
-            "list")
-                #
-                #  For pretty printing, first get all the group names
-                #  and figure out the longest. To keep the code simple
-                #  this is done on the first run of list,
-                #
-                if [ -z "$max_len" ]; then
-                    # first get a list of names, in order to find longest
-                    task="groups"
-                    group_lst="$(process_items)"
-                    task="list" # back to expected processing
+        "list")
+            #
+            #  For pretty printing, first get all the group names
+            #  and figure out the longest. To keep the code simple
+            #  this is done on the first run of list,
+            #
+            if [ -z "$max_len" ]; then
+                # first get a list of names, in order to find longest
+                task="groups"
+                group_lst="$(process_items)"
+                task="list" # back to expected processing
 
-                    max_len=0
-                    while true; do
-                        g="${group_lst%% *}"
-                        group_lst="${group_lst#* }"
+                max_len=0
+                while true; do
+                    g="${group_lst%% *}"
+                    group_lst="${group_lst#* }"
 
-                        g_len="${#g}"
-                        [ "$g_len" -gt "$max_len" ] && max_len="$g_len"
+                    g_len="${#g}"
+                    [ "$g_len" -gt "$max_len" ] && max_len="$g_len"
 
-                        [ "$group_lst" = "$g" ] && break  # list done
-                    done
-                fi
-                printf "[%${max_len}s]  %s\n" "$name" "$packages"
-                ;;
+                    [ "$group_lst" = "$g" ] && break # list done
+                done
+            fi
+            printf "[%${max_len}s]  %s\n" "$name" "$packages"
+            ;;
 
-            "install")
-                if [ "$name" = "$item" ]; then
-                    pkg_handling add
-                    return
-                fi
-                ;;
+        "install")
+            if [ "$name" = "$item" ]; then
+                pkg_handling add
+                return
+            fi
+            ;;
 
-            "uninstall")
-                if [ "$item" = "core" ]; then
-                    echo "ERROR: group core can not be deleted!"
-                    exit 1
-                fi
-                if [ "$name" = "$item" ]; then
-                    pkg_handling del
-                    return
-                fi
-                ;;
-
-            *)
-                echo "ERROR: Unknown task: $task"
+        "uninstall")
+            if [ "$item" = "core" ]; then
+                echo "ERROR: group core can not be deleted!"
                 exit 1
-                ;;
+            fi
+            if [ "$name" = "$item" ]; then
+                pkg_handling del
+                return
+            fi
+            ;;
+
+        *)
+            echo "ERROR: Unknown task: $task"
+            exit 1
+            ;;
 
         esac
-        [ "$lst" = "$section" ] && break  # we have processed last group
+        [ "$lst" = "$section" ] && break # we have processed last group
     done
 }
-
 
 main() {
     echo "$prog_name  $version"
@@ -215,7 +212,6 @@ main() {
         shift
     done
 }
-
 
 use_aok_groups
 

--- a/Debian/setup_debian.sh
+++ b/Debian/setup_debian.sh
@@ -130,9 +130,9 @@ fi
 #
 #  Overriding common runbg with Debian specific, work in progress...
 #
-# msg_2 "Adding runbg service"
-# cp -a "$aok_content"/Devuan/etc/init.d/runbg /etc/init.d
-# ln -sf /etc/init.d/runbg /etc/rc2.d/S04runbg
+msg_2 "Adding runbg service"
+cp -a "$aok_content"/Devuan/etc/init.d/runbg /etc/init.d
+ln -sf /etc/init.d/runbg /etc/rc2.d/S04runbg
 
 #
 #  This is installed by $setup_common_aok, so must come after that!

--- a/build_fs
+++ b/build_fs
@@ -266,11 +266,13 @@ copy_AOK_to_dest() {
     io_conf_overrides="$aok_content"/.AOK_VARS
     if [ -f "$io_conf_overrides" ]; then
         msg_2 "Appending .AOK_CONF on dest FS"
-        echo >>"$io_dst_conf"
-        echo >>"$io_dst_conf"
-        echo "##########   Config overrides   ##########" >>"$io_dst_conf"
-        echo >>"$io_dst_conf"
-        cat "$io_conf_overrides" >>"$io_dst_conf"
+        (
+            echo
+            echo
+            echo "##########   Config overrides   ##########"
+            echo
+            cat "$io_conf_overrides"
+        ) >>"$io_dst_conf"
     fi
     unset io_dst_conf
     unset io_conf_overrides

--- a/build_fs
+++ b/build_fs
@@ -244,42 +244,6 @@ cache_fs_image() {
     # msg_3 "cache_fs_image() done"
 }
 
-integrate_overrides() {
-    msg_2 "integrate_overrides($1)"
-    io_conf_file="$1"
-    case "$io_conf_file" in
-
-    AOK_VARS | tools/utils.sh) ;;
-
-    *)
-        echo "ERROR: integrate_overrides($io_conf_file) - bad param"
-        exit 1
-        ;;
-
-    esac
-
-    io_src_conf="$aok_content"/"$io_conf_file"
-    io_dst_conf="$aok_files"/"$io_conf_file"
-    io_overrides="$aok_content"/.AOK_VARS
-    io_pattrn="###  override handling  ###"
-
-    if [ -f "$io_overrides" ]; then
-        #
-        #  replace include lines with local settings
-        #
-        msg_3 "adding .AOK_VARS  into $io_conf_file on destination"
-        grep -B99999 "$io_pattrn" "$io_src_conf" | grep -v "$io_pattrn" >"$io_dst_conf"
-        cat "$io_overrides" >>"$io_dst_conf"
-    fi
-
-    unset io_conf_file
-    unset io_src_conf
-    unset io_dst_conf
-    unset io_overrides
-    unset io_pattrn
-    # msg_3 "integrate_overrides()  done"
-}
-
 copy_AOK_to_dest() {
     #
     #  Copy AOK content to destination
@@ -298,8 +262,18 @@ copy_AOK_to_dest() {
         --exclude=.AOK_VARS \
         "$aok_content" "$build_root_d"/opt
 
-    integrate_overrides AOK_VARS
-    integrate_overrides tools/utils.sh
+    io_dst_conf="$aok_files"/AOK_VARS
+    io_conf_overrides="$aok_content"/.AOK_VARS
+    if [ -f "$io_conf_overrides" ]; then
+        msg_2 "Appending .AOK_CONF on dest FS"
+        echo >>"$io_dst_conf"
+        echo >>"$io_dst_conf"
+        echo "##########   Config overrides   ##########" >>"$io_dst_conf"
+        echo >>"$io_dst_conf"
+        cat "$io_conf_overrides" >>"$io_dst_conf"
+    fi
+    unset io_dst_conf
+    unset io_conf_overrides
 
     chown -R root: "$aok_files"
     # msg_3 "copy_AOK_to_dest() done"

--- a/tools/utils.sh
+++ b/tools/utils.sh
@@ -539,23 +539,3 @@ setup_debian_scr="$aok_content"/Debian/setup_debian.sh
 setup_devuan_scr="$aok_content"/Devuan/setup_devuan.sh
 setup_select_distro_prepare="$aok_content"/choose_distro/select_distro_prepare.sh
 setup_select_distro="$aok_content"/choose_distro/select_distro.sh
-
-# =====================================================================
-#
-#  Local overrides, ignored by git. They will be appended to build_env
-#  for the deployed image if found.
-#  This is intended for debuging and testing, and appends the same
-#  override file as in AOK_VARS, to ensure overrides to settings here
-#  take effect.
-#  This way on the deployed platform it will be easy to spot what
-#  temp/devel settings was used in the build process.
-#
-# =====================================================================
-
-###  override handling  ###
-
-local_overrides="${aok_content}/.AOK_VARS"
-
-#  shellcheck disable=SC1090
-[ -f "$local_overrides" ] && . "$local_overrides"
-unset local_overrides

--- a/tools/utils.sh
+++ b/tools/utils.sh
@@ -28,13 +28,6 @@ aok_content="/opt/AOK"
 aok_content_etc="/etc$aok_content"
 
 #
-#  Import settings
-#
-
-#  shellcheck disable=SC1091
-. "$aok_content"/AOK_VARS || exit 1
-
-#
 #  Display an error message, second optional param is exit code,
 #  defaulting to 1. If exit code is 0 this will not exit, just display
 #  the error message, then continue.
@@ -395,6 +388,31 @@ run_additional_tasks_if_found() {
     fi
     # msg_3 "run_additional_tasks_if_found()  done"
 }
+
+#===============================================================
+#
+#   Main
+#
+#===============================================================
+
+#
+#  Import settings
+#
+#  shellcheck disable=SC1091
+. "$aok_content"/AOK_VARS || exit 1
+
+#
+#  Read .AOK_VARS if pressent, allowing it to overide AOK_VARS
+#
+if [ "$(echo "$0" | sed 's/\// /g' | awk '{print $NF}')" = "build_fs" ]; then
+    conf_overrides="${aok_content}/.AOK_VARS"
+    if [ -f "$conf_overrides" ]; then
+        msg_1 "Found .AOK_VARS"
+        #  shellcheck disable=SC1090
+        . "$conf_overrides"
+    fi
+    unset conf_overrides
+fi
 
 #
 #  Detecting build environments


### PR DESCRIPTION
1) fixed importing of .AOK_VARS to avoid fork bombs removed inline include stuff, now one can copy AOK_VARS to .AOK_VARS and modify it.

2) fixed aok_groups only to read _APKS variables, and now one can override existing and add _APKS groups in .AOK_VARS
If a group is set to "" it will not be displayed by aok_groups
