### PR TITLE
Updates to README and some small tweaks

### DIFF
--- a/AOK_VARS
+++ b/AOK_VARS
@@ -141,7 +141,7 @@ DOCS_APKS='openssh-doc openrc-doc nload-doc htop-doc procps-doc tmux-doc mandoc 
 #
 #  If a Debian install is selected, this tarball will be used as base image
 #
-DEBIAN_SRC_IMAGE="https://www.dropbox.com/s/6w71oponu7hfr13/Debian10-ish-base-v27.tgz"
+DEBIAN_SRC_IMAGE="https://www.dropbox.com/s/6po880laygb9nyh/Debian10-ish-base-v28.tgz"
 DEVUAN_SRC_IMAGE="https://www.dropbox.com/s/6om4wppspe1pno7/Devuan_4-ish-base-v6.tgz"
 
 #

--- a/AOK_VARS
+++ b/AOK_VARS
@@ -141,7 +141,7 @@ DOCS_APKS='openssh-doc openrc-doc nload-doc htop-doc procps-doc tmux-doc mandoc 
 #
 #  If a Debian install is selected, this tarball will be used as base image
 #
-DEBIAN_SRC_IMAGE="https://www.dropbox.com/s/6po880laygb9nyh/Debian10-ish-base-v28.tgz"
+DEBIAN_SRC_IMAGE="https://www.dropbox.com/s/uzga9vf2rc2w2wg/Debian10-ish-base-v29.tgz"
 DEVUAN_SRC_IMAGE="https://www.dropbox.com/s/6om4wppspe1pno7/Devuan_4-ish-base-v6.tgz"
 
 #

--- a/Alpine/etc/inittab
+++ b/Alpine/etc/inittab
@@ -1,4 +1,4 @@
-# /etc/inittab
+# inittab
 
 # Ensure all devices  are ok
 ::sysinit:/usr/local/sbin/fix_dev

--- a/Debian/setup_debian.sh
+++ b/Debian/setup_debian.sh
@@ -133,6 +133,9 @@ msg_script_title "setup_debian.sh  Debian specific AOK env"
 msg_2 "Running fix_dev"
 /opt/AOK/common_AOK/usr_local_sbin/fix_dev
 
+msg_3 "Create /var/log/wtmp"
+touch /var/log/wtmp
+
 start_setup Debian "$(cat /etc/debian_version)"
 
 if test -f /AOK; then

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ run `build_fs -s` to create a Distro asking if you want to use Alpine,
 Debian or Devuan.
 
 This is the recomended build method if you don't need to prebuild.
-Initial tarball will be arround 10MB. Asuming the target device is
+Initial tarball will be arround 8MB. Asuming the target device is
 resonably modern, the deploy should not take too long.
 
 ## Prebuilt FS

--- a/README.md
+++ b/README.md
@@ -13,20 +13,22 @@ You can build the FS on any platform, but for chrooting (Prebuilding FS, or test
 
 ## Distros available
 
-### Alpine
+### Alpine FS
 
 Fully usable
 
-### Debian
+### Debian FS
 
 Fully usable
 
-#### Known Debian issues
+#### Known Debian FS issues
+
+##### Using Blink
+
+When disconnecting from an iSH-AOK Debian FS session, it is left hanging.
+You need to hit Enter to get back to the Blink prompt.
 
 ##### Building it
-
-Building a Debian FS, then chrooting into it on your iOS device does not work fully.
-It gets going, but any further apt installs tend to fail.
 
 For now the two recomended and working build methods are:
 
@@ -34,8 +36,6 @@ For now the two recomended and working build methods are:
 - Build the FS on a Linux (x86) node, then mount the resulting FS image as a new FS & reboot into it
 
 These two methods have been tested and work both with and without the prebuilt option.
-
-On a Linux(x86) node you can successfully chroot into the new FS, services does not work, and there is no /proc/ish But you can do additional apt installs and stuff like that, then when completed tar it and mount as a new FS on your iOS device
 
 ##### Specific iSH-AOK services
 

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,8 @@
 - Generating bzip2 images only results in very moderate size reductions
 should be investigated to hopefully generate smaller images.
 
+- Alpine/etc/motd_template, the embedded urls doesnt seem to work
+
 ## runbg
 
 use posix script for Debian/Devuan

--- a/build_fs
+++ b/build_fs
@@ -25,7 +25,7 @@ Available options:
 
 -h  --help         Print this help and exit
 -v  --verbose      Displays extra info, like untaring/taring progress
--s  --select       Offer selection between Alpine & Debian on first boot.
+-s  --select       Offer selection between Alpine, Debian & Devuan on first boot.
 -d  --debian       Build a Debian FS.
 -D  --devuan       Build a Devuan FS.
 -p  --prebuilt     Build the entire FS on the running platform, making

--- a/choose_distro/select_distro.sh
+++ b/choose_distro/select_distro.sh
@@ -13,11 +13,10 @@
 select_distro() {
     text="
 Alpine is the regular AOK FS, fully stable.
-This will install Alpine $ALPINE_VERSION
 
 Debian is version 10 (Buster). It was end of lifed 2022-07-18 and is
-thus now unmaintained. It should be fine for testing Debian with
-the AOK FS extensions under iSH-AOK.
+thus now unmaintained except for security updates.
+It should be fine for testing Debian with the AOK FS extensions under iSH-AOK.
 
 Devuan is still experimental. It has DNS issues, enough is in /etc/hosts
 for basic apt actions

--- a/compress_image
+++ b/compress_image
@@ -14,13 +14,13 @@ show_help() {
     cat <<EOF
 Usage: $prog_name [-h] [-v] [-z]
 
-This creates a compressed tar file. that iSH can mount as a file syste,
+This creates a compressed tar file. that iSH can mount as a file system
+It autodetects FS type, and will use a matching filename for the tarball.
 
 Available options:
 
 -h  --help         Print this help and exit.
--l  --label        Provide a name for tarball (without extension)
-                   if not given, Alpine is asumed.
+-l  --label        Provide a name for tarball (without path or extension)
 -j  --bzip2        Use bzip2 compression
 -v  --verbose      Display progrss as FS is being compressed.
 EOF
@@ -149,6 +149,9 @@ if is_ish; then
     cp "$tarball" "$icloud_archive_d"
 fi
 
-msg_1 "Image is ready!"
-
+if $verbose; then
+    msg_1 "Image is ready - $tarball"
+else
+    msg_1 "Image is ready!"
+fi
 exit 0 #  Avoid exiting with error if above file did not exist

--- a/tools/utils.sh
+++ b/tools/utils.sh
@@ -555,10 +555,10 @@ unset _vers
 #  Names of the generated distribution tarballs, no ext, that is ecided
 #  upon during compression
 #
-alpine_tb="iSH-AOK-Alpine-${ALPINE_VERSION}-$AOK_VERSION"
-select_distro_tb="iSH-AOK-SelectDistro-$AOK_VERSION"
-debian_tb="iSH-AOK-Debian-$AOK_VERSION"
-devuan_tb="iSH-AOK-Devuan-$AOK_VERSION"
+alpine_tb="AOK-Alpine-${ALPINE_VERSION}-$AOK_VERSION"
+select_distro_tb="AOK-SelectDistro-$AOK_VERSION"
+debian_tb="AOK-Debian-$AOK_VERSION"
+devuan_tb="AOK-Devuan-$AOK_VERSION"
 
 target_alpine="Alpine"
 target_debian="Debian"

--- a/tools/utils.sh
+++ b/tools/utils.sh
@@ -286,6 +286,7 @@ should_icloud_be_mounted() {
         msg_3 "This is not iSH, skipping /iCloud mount check"
         return
     fi
+
     if is_iCloud_mounted; then
         msg_3 "was already mounted, returning"
         return
@@ -311,13 +312,6 @@ should_icloud_be_mounted() {
             error_msg "Unrecognized distro, aborting"
         fi
         unset sibm_dependency
-    fi
-
-    #  Abort if not running on iSH
-    if ! test -d /proc/ish; then
-        msg_3 "Not runing on iSH /iCloud mount not checked"
-        unset sibm_dlg_app
-        return
     fi
 
     if bldstat_get "$status_prebuilt_fs" && bldstat_get "$status_is_chrooted"; then


### PR DESCRIPTION
- Mentions that Blink needs you to hit enter when disconnecting from Debian FS
- Removed a redundant is_ish check
- Updated some help texts
- added en_GB.UTF-8 to be able to show European-style time, should probably be done in the build_tools in the future to make it more configurable
- shortened the filenames for tarballs iSH-AOK -> AOK makes it easier to see the Distro type on iPhone screens
- Almost forgot, creating /var/log/wtmp added