### PR TITLE
Fix for Alpine pre-builds

### DIFF
--- a/Alpine/setup_alpine.sh
+++ b/Alpine/setup_alpine.sh
@@ -5,6 +5,8 @@
 #
 #  License: MIT
 #
+#  setup_alpine.sh
+#
 #  This modifies an Alpine Linux FS with the AOK changes
 #
 

--- a/Alpine/setup_alpine_final_tasks.sh
+++ b/Alpine/setup_alpine_final_tasks.sh
@@ -8,6 +8,8 @@
 #
 #  Copyright (c) 2023: Jacob.Lundqvist@gmail.com
 #
+#  setup_alpine_final_tasks.sh
+#
 #  Completes the setup of Alpine.
 #  On normal installs, this runs at the end of the install.
 #  On pre-builds this will be run on first boot at destination device

--- a/Debian/setup_debian.sh
+++ b/Debian/setup_debian.sh
@@ -6,6 +6,8 @@
 #
 #  License: MIT
 #
+#  setup_debian.sh
+#
 #  Copyright (c) 2023: Jacob.Lundqvist@gmail.com
 #
 #  This modifies a Debian Linux FS with the AOK changes

--- a/Debian/setup_debian_final_tasks.sh
+++ b/Debian/setup_debian_final_tasks.sh
@@ -6,6 +6,8 @@
 #
 #  License: MIT
 #
+#  setup_debian_final_tasks.sh
+#
 #  Copyright (c) 2023: Jacob.Lundqvist@gmail.com
 #
 #  Completes the setup of Debian.

--- a/Devuan/setup_devuan.sh
+++ b/Devuan/setup_devuan.sh
@@ -6,6 +6,8 @@
 #
 #  License: MIT
 #
+#  setup_devuan.sh
+#
 #  Copyright (c) 2023: Jacob.Lundqvist@gmail.com
 #
 #  This modifies a Devuan Linux FS with the AOK changes

--- a/Devuan/setup_devuan_final_tasks.sh
+++ b/Devuan/setup_devuan_final_tasks.sh
@@ -6,6 +6,8 @@
 #
 #  License: MIT
 #
+#  setup_devuan_final_tasks.sh
+#
 #  Copyright (c) 2023: Jacob.Lundqvist@gmail.com
 #
 #  Completes the setup of Debian.

--- a/build_fs
+++ b/build_fs
@@ -334,17 +334,6 @@ prebuild_fs() {
             if [ -n "$AOK_APKS" ]; then
                 msg_3 "AOK_APKS will be deleted on first boot if not iSH-AOK kernel"
             fi
-            if [ -n "$AOK_APKS" ]; then
-                select_profile "$setup_alpine_final"
-            else
-                #  Clear up build env
-                bldstat_clear_all
-                select_profile "$aok_content"/Alpine/etc/profile
-            fi
-            #
-            #  Since some final steps need to run by the above profile
-            #  mark the FS as in build state
-            #
         fi
     else
         msg_3 "QUICK_DEPLOY - skipping removal of AOK kernel packages"

--- a/tools/utils.sh
+++ b/tools/utils.sh
@@ -250,7 +250,7 @@ select_profile() {
     #
     chmod 744 "$build_root_d"/etc/profile
     unset sp_new_profile
-    msg_3 "select_profile() done"
+    # msg_3 "select_profile() done"
 }
 
 user_interactions() {


### PR DESCRIPTION
- Removed incorrect profile change for Alpine when pre-built
- Added script names in header of scripts acting as /etc/profile during deploy, this makes it easier to quickly see what the next step will be
- Reduced verbosity for select_profile, exit notification is pretty redundant.