### PR TITLE
aok displays current login method, display 0 prefix in display_time if value < 10, and some choose_distro fixes

### DIFF
--- a/Debian/setup_debian.sh
+++ b/Debian/setup_debian.sh
@@ -228,7 +228,7 @@ fi
 
 msg_1 "Setup complete!"
 
-duration="$(($(date +%s) - tsd_start))"
+duration="$(($(date +%s) - $tsd_start))"
 display_time_elapsed "$duration" "Setup Debian"
 
 if [ "$not_prebuilt" = 1 ]; then

--- a/Devuan/etc/hosts
+++ b/Devuan/etc/hosts
@@ -1,4 +1,4 @@
-27.0.0.1 localhost
+127.0.0.1 localhost
 ::1 localhost ip6-localhost ip6-loopback
 ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters

--- a/Devuan/setup_devuan.sh
+++ b/Devuan/setup_devuan.sh
@@ -210,7 +210,7 @@ fi
 
 msg_1 "Setup complete!"
 
-duration="$(($(date +%s) - tsd_start))"
+duration="$(($(date +%s) - $tsd_start))"
 display_time_elapsed "$duration" "Setup Devuan"
 
 if [ "$not_prebuilt" = 1 ]; then

--- a/choose_distro/install_debian.sh
+++ b/choose_distro/install_debian.sh
@@ -18,7 +18,7 @@ msg_script_title "install_debian.sh  Downloading & Installing Debian"
 
 debian_download_location="/tmp/debian_fs"
 src_image="$DEBIAN_SRC_IMAGE"
-src_tarball="/$debian_download_location/$debian_src_tb"
+src_tarball="$debian_download_location/$debian_src_tb"
 
 mkdir -p "$debian_download_location"
 cd "$debian_download_location" || {

--- a/choose_distro/install_devuan.sh
+++ b/choose_distro/install_devuan.sh
@@ -18,7 +18,7 @@ msg_script_title "install_devuan.sh  Downloading & Installing Devuan"
 
 devuan_download_location="/tmp/devuan_fs"
 src_image="$DEVUAN_SRC_IMAGE"
-src_tarball="/$devuan_download_location/$devuan_src_tb"
+src_tarball="$devuan_download_location/$devuan_src_tb"
 
 mkdir -p "$devuan_download_location"
 cd "$devuan_download_location" || {

--- a/choose_distro/select_distro.sh
+++ b/choose_distro/select_distro.sh
@@ -82,11 +82,13 @@ fi
 # shellcheck disable=SC1091
 . /opt/AOK/tools/utils.sh
 
+tcd_start="$(date +%s)"
+
 #  Ensure important devices are present
 msg_2 "Running fix_dev"
 /opt/AOK/common_AOK/usr_local_sbin/fix_dev
 
 select_distro
 
-duration="$(($(date +%s) - tcd_start))"
+duration="$(($(date +%s) - $tcd_start))"
 display_time_elapsed "$duration" "Choose Distro"

--- a/choose_distro/select_distro.sh
+++ b/choose_distro/select_distro.sh
@@ -29,6 +29,7 @@ Select distro:
     echo
     echo "$text"
     read -r selection
+    echo
     case "$selection" in
 
     1)
@@ -51,7 +52,6 @@ Select distro:
         ;;
 
     *)
-        echo
         echo "*****   Invalid selection   *****"
         sleep 1
         select_distro

--- a/common_AOK/usr_local_bin/aok
+++ b/common_AOK/usr_local_bin/aok
@@ -8,7 +8,6 @@
 #
 #  Script to do various things related to the configuration of ish
 #
-version="0.3.1  2023-02-25"
 
 show_help() {
     cat <<EOF
@@ -21,9 +20,8 @@ Currently only login procedure can be altered.
 Available options:
 
 -h, --help      Print this help and exit
--V, --version   Display version and exit
 -v, --verbose   Be verbose
--l, --login     Decides login procedure [once|disable|enable]
+-l, --login     Decides login procedure [once|disable|enable] Now: $(display_login_method)
 EOF
     exit 0
 }
@@ -86,6 +84,16 @@ change_login_procedure() {
     esac
 }
 
+display_login_method() {
+    if ls -l /bin/login | grep -q login.loop; then
+        echo "enabled"
+    elif ls -l /bin/login | grep -q login.once; then
+        echo "once"
+    else
+        echo "disabled"
+    fi
+}
+
 #===============================================================
 #
 #   Main
@@ -114,11 +122,6 @@ while true; do
         show_help
         ;;
 
-    "-V" | "--version")
-        echo "$prog_name  $version"
-        exit 0
-        ;;
-
     "-v" | "--verbose")
         if [ "$verbose" -eq 0 ]; then
             echo "===  Enabling verbose mode  ==="
@@ -131,7 +134,12 @@ while true; do
         ;;
 
     "-l" | "--login")
-        change_login_procedure "$2"
+        if [ -n "$2" ]; then
+            change_login_procedure "$2"
+        else
+            printf "Current login method: "
+            display_login_method
+        fi
         ;;
 
     *)

--- a/compress_image
+++ b/compress_image
@@ -91,7 +91,7 @@ if [ "$(find "$build_root_d"/dev | wc -l)" -gt 1 ]; then
 fi
 
 if [ -n "$tar_name" ]; then
-    tarball="${tar_name}"
+    tarball_fn="${tar_name}"
 else
     #
     #  If no tarball name was given, try to identify what is prepared
@@ -104,13 +104,13 @@ else
 
         case "$distro_name" in
 
-        "Alpine") tarball="$alpine_tb" ;;
+        "Alpine") tarball_fn="$alpine_tb" ;;
 
-        "Debian") tarball="$debian_tb" ;;
+        "Debian") tarball_fn="$debian_tb" ;;
 
-        "Devuan") tarball="$devuan_tb" ;;
+        "Devuan") tarball_fn="$devuan_tb" ;;
 
-        "SelectDistro") tarball="$select_distro_tb" ;;
+        "SelectDistro") tarball_fn="$select_distro_tb" ;;
 
         *)
             error_msg "Failed to identify prepared distro: [$distro_name]"
@@ -123,7 +123,7 @@ else
 fi
 
 # set location
-tarball="$build_base_d/$tarball"
+tarball="$build_base_d/$tarball_fn"
 
 # echo "removing temp /dev items"
 # rm  -f "$build_root_d"/dev/*
@@ -154,8 +154,8 @@ tar "$opts" "$tarball" .
 #
 # copy it to /iCloud if this runs on iSH
 #
-if is_ish; then
-    msg_2 "Copying image into $icloud_archive_d"
+if is_ish && [ "$(ls /iCloud | wc -l)" -gt 0 ]; then
+    msg_2 "Creating additional copy: $icloud_archive_d/$tarball_fn"
     mkdir -p "$icloud_archive_d"
     cp "$tarball" "$icloud_archive_d"
 fi

--- a/compress_image
+++ b/compress_image
@@ -138,9 +138,11 @@ cd "$build_root_d" || {
 if $use_bzip2; then
     opts="cfj"
     tarball="${tarball}.tar.bz2"
+    tarball_fn="${tarball_fn}.tar.bz2"
 else
     opts="cfz"
     tarball="${tarball}.tgz"
+    tarball_fn="${tarball_fn}.tgz"
 fi
 
 msg_1 "Creating image $tarball"

--- a/tools/utils.sh
+++ b/tools/utils.sh
@@ -81,6 +81,11 @@ display_time_elapsed() {
 
     dte_mins="$((dte_t_in / 60))"
     dte_seconds="$((dte_t_in - dte_mins * 60))"
+
+    #  Add zero prefix when < 10
+    [ "$dte_mins" -gt 0 ] && [ "$dte_mins" -lt 10 ] && dte_mins="0$dte_mins"
+    [ "$dte_seconds" -lt 10 ] && dte_seconds="0$dte_seconds"
+
     echo
     echo "Time elapsed: $dte_mins:$dte_seconds - $dte_label"
     echo


### PR DESCRIPTION
- aok displays the current login method, both without params, and when -l bot nothing further is given
- Ensure display time to use 0 prefix for time fragments < 10
- Blank line before displaying selection in choose_distro
- Fixed deploy time calculations for Select Distro
- fixed progress display of tarball expansion to not print //

- Fixed Devuan localhost ip# in /etc/hosts (I can't fathom how I managed to miss config that one...)
