### PR TITLE
Add script upgrade and scripts aborting if dependencies not met

### DIFF
--- a/AOK_VARS
+++ b/AOK_VARS
@@ -26,7 +26,7 @@
 AOK_VERSION="Beta-003"
 
 #
-#  If defined this user will be created
+#  If defined this will be created as a no-password sudo capable user
 #
 USER_NAME="ish"
 

--- a/Alpine/usr_local_bin/do_fix_services
+++ b/Alpine/usr_local_bin/do_fix_services
@@ -18,4 +18,5 @@
 # date      >  /tmp/initial-service-status
 # rc-status >> /tmp/initial-service-status
 
-rc-status  |grep -v -e started -e Runlevel: -e started | awk '{cmd="rc-service " $1 " restart" ; system(cmd)}'
+echo "If nothing is displayed, all services are running"
+rc-status | grep -v -e started -e Runlevel: -e started | awk '{cmd="rc-service " $1 " restart" ; system(cmd)}'

--- a/Alpine/usr_local_bin/enable_vnc
+++ b/Alpine/usr_local_bin/enable_vnc
@@ -5,6 +5,11 @@
 #  License: MIT
 #
 
+if [ ! -d /opt/AOK ]; then
+    echo "/opt/AOK missing, this can't continue!"
+    exit 1
+fi
+
 # Read important stuff
 # shellcheck disable=SC1091
 . /opt/AOK/AOK_VARS

--- a/build_fs
+++ b/build_fs
@@ -12,8 +12,7 @@
 #
 
 show_help() { # Multi OK 1
-    cat <<EOF
-Usage: $prog_name [-h] [-v] [-p] [-c] [-z] [-u]
+    echo "Usage: $prog_name [-h] [-v] [-p] [-c] [-z] [-u]
 
 This builds the iSH-AOK filesystem.
 
@@ -34,8 +33,7 @@ Available options:
                    This can only be done on iSH or Linux (x86)!
 -j  --bzip2        Use bzip2 compression for distribution
 -N  --no_compress  Terminates when FS is prepared, without generating
-                   a FS tarball.
-EOF
+                   a FS tarball."
     exit 0
 }
 

--- a/common_AOK/usr_local_bin/aok
+++ b/common_AOK/usr_local_bin/aok
@@ -10,8 +10,7 @@
 #
 
 show_help() {
-    cat <<EOF
-Usage: $prog_name [-h] [-v] [-l login procedure]
+    echo "Usage: $prog_name [-h] [-v] [-l login procedure]
 
 An AOK-only script that manages iSH/AOK specific things.
 
@@ -21,8 +20,7 @@ Available options:
 
 -h, --help      Print this help and exit
 -v, --verbose   Be verbose
--l, --login     Decides login procedure [once|disable|enable] Now: $(display_login_method)
-EOF
+-l, --login     Decides login procedure [once|disable|enable] Now: $(display_login_method)"
     exit 0
 }
 

--- a/common_AOK/usr_local_bin/elock
+++ b/common_AOK/usr_local_bin/elock
@@ -10,19 +10,16 @@ version="2.0.0  2022-05-25"
 
 prog_name=$(basename "$0")
 
-
-if ! [ -f /proc/ish/defaults/enable_extralocking ]; then
+if ! grep -qi aok /proc/ish/version 2>/dev/null; then
     echo "Not running on iSH-AOK, exiting."
-    exit 1;
+    exit 1
 fi
-
 
 # execute again as root
 if [ "$(whoami)" != "root" ]; then
     sudo "$0" "$1"
     exit 0
 fi
-
 
 show_status() {
     STATE="$(cat /proc/ish/defaults/enable_extralocking)"
@@ -32,7 +29,6 @@ show_status() {
         echo "off"
     fi
 }
-
 
 usage() {
     echo "Version:  $version"
@@ -46,34 +42,33 @@ usage() {
     show_status
 }
 
-
 case "$1" in
 
-    "" | "-h" | "--help" )
-	usage
-	exit 0
-	;;
+"" | "-h" | "--help")
+    usage
+    exit 0
+    ;;
 
-    "on" )
-	echo "true" > /proc/ish/defaults/enable_extralocking
-	exit 0
-	;;
+"on")
+    echo "true" >/proc/ish/defaults/enable_extralocking
+    exit 0
+    ;;
 
-    "off" )
-	echo "false" > /proc/ish/defaults/enable_extralocking
-	exit 0
-	;;
+"off")
+    echo "false" >/proc/ish/defaults/enable_extralocking
+    exit 0
+    ;;
 
-    "status" )
-	show_status
-	exit 0
-	;;
+"status")
+    show_status
+    exit 0
+    ;;
 
-    * )
-	echo "ERROR: Unknown option $1"
-	echo
-	usage
-	exit 1
-	;;
+*)
+    echo "ERROR: Unknown option $1"
+    echo
+    usage
+    exit 1
+    ;;
 
 esac

--- a/common_AOK/usr_local_bin/myip
+++ b/common_AOK/usr_local_bin/myip
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if ! grep -qi aok /proc/ish/version 2>/dev/null; then
+    echo "Not running on iSH-AOK, exiting."
+    exit 1
+fi
+
 printf "Internet IP:  "
 if curl -s http://ifconfig.me; then
     printf "\n"

--- a/common_AOK/usr_local_bin/showip
+++ b/common_AOK/usr_local_bin/showip
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if ! grep -qi aok /proc/ish/version 2>/dev/null; then
+    echo "Not running on iSH-AOK, exiting."
+    exit 1
+fi
+
 INT_IP="$(curl ifconfig.me 2>/dev/null)"
 
 echo "Internet IP: $INT_IP"

--- a/common_AOK/usr_local_bin/toggle_multicore
+++ b/common_AOK/usr_local_bin/toggle_multicore
@@ -10,19 +10,16 @@ version="2.0.0  2022-05-25"
 
 prog_name=$(basename "$0")
 
-
-if [ ! -e /proc/ish/defaults/enable_multicore ]; then
-   echo "Not running on iSH-AOK, exiting."
-   exit 1
+if ! grep -qi aok /proc/ish/version 2>/dev/null; then
+    echo "Not running on iSH-AOK, exiting."
+    exit 1
 fi
-
 
 # execute again as root
 if [ "$(whoami)" != "root" ]; then
-     sudo "$0" "$1"
-     exit 0
+    sudo "$0" "$1"
+    exit 0
 fi
-
 
 show_status() {
     STATE="$(cat /proc/ish/defaults/enable_multicore)"
@@ -32,7 +29,6 @@ show_status() {
         echo "off"
     fi
 }
-
 
 usage() {
     echo "Version:  $version"
@@ -46,33 +42,32 @@ usage() {
     show_status
 }
 
-
 case "$1" in
 
-    "" | "-h" | "--help" )
-	usage
-	exit 0
-	;;
+"" | "-h" | "--help")
+    usage
+    exit 0
+    ;;
 
-    "on" )
-	echo "true" > /proc/ish/defaults/enable_multicore
-	exit 0
-	;;
+"on")
+    echo "true" >/proc/ish/defaults/enable_multicore
+    exit 0
+    ;;
 
-    "off" )
-	echo "false" > /proc/ish/defaults/enable_multicore
-	exit 0
-	;;
+"off")
+    echo "false" >/proc/ish/defaults/enable_multicore
+    exit 0
+    ;;
 
-    "status" )
-	show_status
-	exit 0
-	;;
+"status")
+    show_status
+    exit 0
+    ;;
 
-    * )
-	echo "ERROR: Unknown option $1"
-	echo
-	usage
-	exit 1
-	;;
+*)
+    echo "ERROR: Unknown option $1"
+    echo
+    usage
+    exit 1
+    ;;
 esac

--- a/common_AOK/usr_local_sbin/ensure_hostname_in_host_file.sh
+++ b/common_AOK/usr_local_sbin/ensure_hostname_in_host_file.sh
@@ -6,7 +6,8 @@
 #
 #  Copyright (c) 2023: Jacob.Lundqvist@gmail.com
 #
-#  Ensure that hostname is in /etc/hosts, if not
+#  Ensure that hostname is in /etc/hosts, if not add it to loopback
+#
 
 host_file="/etc/hosts"
 host_name="$(hostname | tr '[:upper:]' '[:lower:]')"

--- a/compress_image
+++ b/compress_image
@@ -11,8 +11,7 @@
 #
 
 show_help() {
-    cat <<EOF
-Usage: $prog_name [-h] [-v] [-z]
+    echo "Usage: $prog_name [-h] [-v] [-z]
 
 This creates a compressed tar file. that iSH can mount as a file system
 It autodetects FS type, and will use a matching filename for the tarball.
@@ -22,8 +21,7 @@ Available options:
 -h  --help         Print this help and exit.
 -l  --label        Provide a name for tarball (without path or extension)
 -j  --bzip2        Use bzip2 compression
--v  --verbose      Display progrss as FS is being compressed.
-EOF
+-v  --verbose      Display progrss as FS is being compressed."
     exit 0
 }
 

--- a/tools/upgrade_bins.sh
+++ b/tools/upgrade_bins.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# shellcheck disable=SC2154
+
+#
+#  Part of https://github.com/emkey1/AOK-Filesystem-Tools
+#
+#  License: MIT
+#
+#  Copyright (c) 2023: Jacob.Lundqvist@gmail.com
+#
+#  upgrades /usr/local/bin & /usr/local/sbin with latest versions
+#  from /opt/AOK, both common and distro based items
+#
+
+#===============================================================
+#
+#   Main
+#
+#===============================================================
+
+# execute again as root
+if [ "$(whoami)" != "root" ]; then
+    echo "Executing as root"
+    # using $0 instead of full path makes location not hardcoded
+    if ! sudo "$0" "$@"; then
+        echo
+        echo "ERROR: Failed to sudo $0"
+        echo
+    fi
+    exit 0
+fi
+
+if [ ! -d /opt/AOK ]; then
+    echo "/opt/AOK missing, this can't continue!"
+    exit 1
+fi
+
+echo
+echo "Upgrading /usr/local/bin & /usr/local/bin with current items from /opt/AOK"
+echo
+
+#
+#  Always copy common stuff
+#
+cp -av /opt/AOK/common_AOK/usr_local_bin/* /usr/local/bin
+cp -av /opt/AOK/common_AOK/usr_local_sbin/* /usr/local/sbin
+
+#
+#  Copy distro specific stuff
+#
+if [ -f /etc/alpine-release ]; then
+    cp -av /opt/AOK/Alpine/usr_local_bin/* /usr/local/bin
+    cp -av /opt/AOK/Alpine/usr_local_sbin/* /usr/local/sbin
+elif [ -f /etc/devuan_version ]; then
+    cp -av /opt/AOK/Devuan/usr_local_bin/* /usr/local/bin
+    cp -av /opt/AOK/Devuan/usr_local_sbin/* /usr/local/sbin
+elif [ -f /etc/debian_version ]; then
+    cp -av /opt/AOK/Debian/usr_local_bin/* /usr/local/bin
+    cp -av /opt/AOK/Debian/usr_local_sbin/* /usr/local/sbin
+else
+    echo "ERROR: Failed to recognize Distro, aborting."
+    exit 1
+fi


### PR DESCRIPTION
- new script /opt/AOK/tools/upgrade_bins.sh - Updates /usr/local/bin & /usr/local/sbin with the latest content from /opt/AOK, both common & distro specific items
- prevent relevant deployed scripts from running if not iSH-AOK kernel
- prevent some stuff from running if /opt/AOK is not present
- replaced 'cat <<EOF' with echo for help texts
- some minor stuff