### PR TITLE
safer bin upgrades

### DIFF
--- a/AOK_VARS
+++ b/AOK_VARS
@@ -109,7 +109,10 @@ CORE_APKS="busybox-extras coreutils findutils ncurses openrc openssh shadow sudo
 #
 #  Additional packages. These don't work with stock iSH but work with
 #  iSH-AOK and will probably work with the Linux Kernel iSH
-#  Will only be installed if the kernel is identified as iSH-AOK
+#  Will only be installed if the kernel is identified as iSH-AOK.
+#  If doing a prebuild, these will be installed regardless of
+#  build platform, then on first boot at dest device, they
+#  will be removed if at this time the env is not iSH-AOK
 #
 AOK_APKS="procps nload"
 
@@ -123,10 +126,10 @@ AOK_APKS="procps nload"
 #
 #  You can add/modify all the groups to your liking.
 #  Again, consider using .AOK_VARS
-
+#
 VNC_APKS='x11vnc xvfb xterm xorg-server xf86-video-dummy i3wm i3status i3lock xdpyinfo xdpyinfo-doc i3wm-doc i3lock-doc i3status-doc ttf-dejavu'
 
-DEVEL_APKS='py3-pip python3-dev build-base linux-headers cmake'
+DEVEL_APKS='build-base linux-headers cmake automake autoconf byacc py3-pip libffi-dev openssl-dev bzip2-dev zlib-dev xz-dev readline-dev sqlite-dev tk-dev libevent-dev ncurses-dev python3-dev'
 NODEJS_APKS='nodejs nodejs-dev'
 # BLOAT3_APKS='emacs neofetch'
 

--- a/Debian/bin/login.loop.sh
+++ b/Debian/bin/login.loop.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-while true; do
-    [ -f /etc/issue ] && cat /etc/issue
-    /bin/login.original
-done

--- a/Debian/bin/login.once.sh
+++ b/Debian/bin/login.once.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-[ -f /etc/issue ] && cat /etc/issue
-/bin/login.original

--- a/tools/upgrade_bins.sh
+++ b/tools/upgrade_bins.sh
@@ -18,6 +18,18 @@
 #
 #===============================================================
 
+if [ ! -d /opt/AOK ]; then
+    echo "/opt/AOK missing, this can't continue!"
+    exit 1
+fi
+
+#  shellcheck disable=SC1091
+. /opt/AOK/tools/utils.sh
+
+if ! is_ish; then
+    error_msg "This should only be run on an iSH platform!"
+fi
+
 # execute again as root
 if [ "$(whoami)" != "root" ]; then
     echo "Executing as root"
@@ -28,11 +40,6 @@ if [ "$(whoami)" != "root" ]; then
         echo
     fi
     exit 0
-fi
-
-if [ ! -d /opt/AOK ]; then
-    echo "/opt/AOK missing, this can't continue!"
-    exit 1
 fi
 
 echo


### PR DESCRIPTION
- upgrade_bins.sh will only run on iSH platform, realised this could unintentionally be triggered on Mac & Linux as well.
- Removed two long-since obsolete files from Debian/bin
- Added some DEVEL_APKS I use when building tmux and python in the asdf version manager, if you find it excessive and not generally useful, feel free to reset DEVEL_APKS to your prefs, I can always keep mine in my .AOK_VARS :)