### PR TITLE
Fixed esc prefixing on Debian

### DIFF
--- a/common_AOK/usr_local_bin/nav_keys.sh
+++ b/common_AOK/usr_local_bin/nav_keys.sh
@@ -39,9 +39,9 @@ tmux_mod_arrow() {
 
     {
         echo "bind -n  ${t_mod}-Up     send-keys PageUp"
-        echo "bind -n  ${t_mod}-Down   send-keys PageUp"
-        echo "bind -n  ${t_mod}-Left   send-keys PageUp"
-        echo "bind -n  ${t_mod}-Right  send-keys PageUp"
+        echo "bind -n  ${t_mod}-Down   send-keys PageDown"
+        echo "bind -n  ${t_mod}-Left   send-keys Home"
+        echo "bind -n  ${t_mod}-Right  send-keys End"
     } >"$f_tmux_nav_key_handling"
 }
 

--- a/common_AOK/usr_local_bin/nav_keys.sh
+++ b/common_AOK/usr_local_bin/nav_keys.sh
@@ -46,7 +46,11 @@ tmux_mod_arrow() {
 }
 
 tmux_esc_prefix() {
-    sequence="$1"
+    #
+    #  At least Esc must be converted from octal to special char
+    #  for older tmux versions. Doesnt hurt on newer
+    #
+    sequence="$(echo $1 | sed 's/\\033/\\e/g')"
     if [ "$sequence" = " " ]; then
         echo "No special tmux Escape handling requested"
         clear_nav_key_usage

--- a/common_AOK/usr_local_bin/nav_keys.sh
+++ b/common_AOK/usr_local_bin/nav_keys.sh
@@ -61,15 +61,13 @@ tmux_esc_prefix() {
     {
         echo
         echo "# For this to work, escape-time needs to be zero, or at least pretty low"
-        echo
         echo "set -s escape-time 0"
+        echo
 
         echo "# Using Esc prefix for nav keys"
-        echo
         echo "set -s user-keys[200]  \"$sequence\"" # multiKeyBT
-
         echo "bind -n User200 switch-client -T multiKeyBT"
-
+        echo
         echo "bind -T multiKeyBT  Down     send PageDown"
         echo "bind -T multiKeyBT  Up       send PageUp"
         echo "bind -T multiKeyBT  Left     send Home"


### PR DESCRIPTION
Or rather for older versions of tmux. Modern tmux accepts oct sequences for key definition, and they are great when capturing odd keys that generate non ascii sequences when pressed. Older versions does not, so I now change \033 into \e This solves Esc for older tmux, and works on newer versions.